### PR TITLE
Add pthread-stubs as a runtime dependency

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,6 +32,11 @@ if [ -n "$CYGWIN_PREFIX" ] ; then
         -I "$BUILD_PREFIX_M/Library/mingw-w64/share/aclocal"
     )
     autoreconf "${autoreconf_args[@]}"
+
+    # And we need to add the search path that lets libtool find the
+    # msys2 stub libraries for ws2_32.
+    platlibs=$(cd $(dirname $(gcc --print-prog-name=ld))/../lib && pwd -W)
+    export LDFLAGS="$LDFLAGS -L$platlibs"
 fi
 
 export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
@@ -75,7 +80,7 @@ xcb-xvmc
 "
 
 # Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
-if [ -z "VS_MAJOR" ] ; then
+if [ -z "$CYGWIN_PREFIX" ] ; then
     for lib_ident in $xcb_libs ; do
         rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
     done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,38 @@ requirements:
 
 test:
   commands:
+    {% set lib_idents = [
+      "xcb",
+      "xcb-composite",
+      "xcb-damage",
+      "xcb-dpms",
+      "xcb-dri2",
+      "xcb-glx",
+      "xcb-present",
+      "xcb-randr",
+      "xcb-record",
+      "xcb-res",
+      "xcb-screensaver",
+      "xcb-shape",
+      "xcb-shm",
+      "xcb-sync",
+      "xcb-xf86dri",
+      "xcb-xfixes",
+      "xcb-xinerama",
+      "xcb-xkb",
+      "xcb-xtest",
+      "xcb-xv",
+      "xcb-xvmc",
+    ] %}
+    {% set lib_idents = lib_idents + ['xcb-dri3'] %}  # [not win]
+    {% for lib_ident in lib_idents %}
+    - test -f $PREFIX/lib/lib{{ lib_ident }}.dylib  # [osx]
+    - test -f $PREFIX/lib/lib{{ lib_ident }}.so  # [linux]
+    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.dll.a exit /b 1  # [win]
+    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.a exit /b 1  # [win]
+    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.la exit /b 1  # [win]
+    - if not exist %PREFIX%/Library/bin/msys-{{ lib_ident }}-*.dll exit /b 1  # [win]
+    {% endfor %}
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -38,6 +38,7 @@ requirements:
     - xcb-proto >=1.13
     - xorg-xproto
   run:
+    - pthread-stubs
     - xorg-libxau
     - xorg-libxdmcp
 


### PR DESCRIPTION
Without including this, every single package that does a pkg-config check for the `xcb` module needs to remember to pull in `pthread-stubs` as a dependency: XCB's pkg-config file requires `pthread-stubs.pc` and pkg-config checks will fail if the latter isn't available. This is admittedly a secondary use case, but this problem keeps on biting me, and it can cause subtle failures because problems happen even when a package only depends implicitly on libxcb.

Ideally, instead of this, we'd start having `-devel` packages and/or dev-only dependencies, but conda-build and conda-forge are a long ways away from that. The extra package to install is annoying but it contains literally just the one pkg-config file.

Alternatively one could start bundling `pthread-stubs.pc` in with this package, but the standalone package already exists (in `defaults` too) so I feel that it's better to just go ahead and use it.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
