### PR TITLE
Provide Libtool's `.la` files once again.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - windows.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
I had intended not to include these files in the original package, but due to a typo, they had been included. As alluded to in the code comment in `build.sh`, removing these files turns out to be a breaking change that has been messing up builds. At the moment, the most sensible course of action seems to be to go back to providing these. However, we start emulating Debian by blanking out the `dependency_libs` item in the `.la` files, which causes the interdependencies and is not needed now that virtually everyone uses `pkg-config`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
