### PR TITLE
Stop packaging Libtool `.la` files.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - windows.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -67,13 +67,12 @@ test:
       "xcb-xv",
       "xcb-xvmc",
     ] %}
-    {% set lib_idents = lib_idents + ['xcb-dri3'] %}  # [not win]
+    {% set lib_idents = lib_idents + ['xcb-dri3', 'xcb-render', 'xcb-xinput'] %}  # [not win]
     {% for lib_ident in lib_idents %}
     - test -f $PREFIX/lib/lib{{ lib_ident }}.dylib  # [osx]
     - test -f $PREFIX/lib/lib{{ lib_ident }}.so  # [linux]
     - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.dll.a exit /b 1  # [win]
     - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.a exit /b 1  # [win]
-    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.la exit /b 1  # [win]
     - if not exist %PREFIX%/Library/bin/msys-{{ lib_ident }}-*.dll exit /b 1  # [win]
     {% endfor %}
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]


### PR DESCRIPTION
Pursuant to https://github.com/conda-forge/staged-recipes/issues/673 and https://github.com/conda-forge/libxcb-feedstock/pull/9, we're going to remove these files from our packages. Eventually conda-build will do this automatically for us, but for now we take care of it manually. We need to delete the files both before the build (because inconsistent complements of `.la` files can break the build) and after because we may have installed new ones).

CC @jakirkham @mingwandroid @isuruf @ocefpaf @bgruening 

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

