### PR TITLE
Tidy libtool code [skip ci] [ci skip]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,7 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_c_compilervs2008
-      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
-
-    - CONFIG: win_c_compilervs2015
+    - CONFIG: win_
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -1,4 +1,2 @@
-c_compiler:
-- vs2008
 m2w64_c_compiler:
 - m2w64-toolchain

--- a/.ci_support/win_c_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015.yaml
@@ -1,4 +1,0 @@
-c_compiler:
-- vs2015
-m2w64_c_compiler:
-- m2w64-toolchain

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,8 +22,9 @@ fi
 
 # Cf. https://github.com/conda-forge/staged-recipes/issues/673, we're in the
 # process of excising Libtool files from our packages. Existing ones can break
-# the build while this happens.
-find $PREFIX -name '*.la' -delete
+# the build while this happens. We have "/." at the end of $uprefix to be safe
+# in case the variable is empty.
+find $uprefix/. -name '*.la' -delete
 
 # On Windows we need to regenerate the configure scripts.
 if [ -n "$CYGWIN_PREFIX" ] ; then
@@ -47,6 +48,7 @@ fi
 export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
 configure_args=(
     --prefix=$mprefix
+    --disable-static
     --disable-dependency-tracking
     --disable-selective-werror
     --disable-silent-rules
@@ -59,43 +61,9 @@ make check
 
 rm -rf $uprefix/share/man $uprefix/share/doc/${PKG_NAME#xorg-}
 
-xcb_libs="
-xcb
-xcb-composite
-xcb-damage
-xcb-dpms
-xcb-dri2
-xcb-dri3
-xcb-glx
-xcb-present
-xcb-randr
-xcb-record
-xcb-render
-xcb-res
-xcb-screensaver
-xcb-shape
-xcb-shm
-xcb-sync
-xcb-xf86dri
-xcb-xfixes
-xcb-xinerama
-xcb-xinput
-xcb-xkb
-xcb-xtest
-xcb-xv
-xcb-xvmc
-"
-
-# Non-Windows: prefer dynamic libraries to static
-if [ -z "$CYGWIN_PREFIX" ] ; then
-    for lib_ident in $xcb_libs ; do
-        rm -f $uprefix/lib/lib${lib_ident}.a
-    done
-fi
-
 # Remove any new Libtool files we may have installed. It is intended that
 # conda-build will eventually do this automatically.
-find $PREFIX -name '*.la' -delete
+find $uprefix/. -name '*.la' -delete
 
 if [ "$(uname)" == "Linux" ]; then
     # Build a dummy libxcb-xlib. This library used to exist, but was

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,6 @@ test:
     - test -f $PREFIX/lib/lib{{ lib_ident }}.dylib  # [osx]
     - test -f $PREFIX/lib/lib{{ lib_ident }}.so  # [linux]
     - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.dll.a exit /b 1  # [win]
-    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.a exit /b 1  # [win]
     - if not exist %PREFIX%/Library/bin/msys-{{ lib_ident }}-*.dll exit /b 1  # [win]
     {% endfor %}
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]


### PR DESCRIPTION
This adjusts the `build.sh` to match what the other X.org packages are going to look like, to aid in future mass patching.

Also rerender, which drops one of the Windows variants.